### PR TITLE
Fix for createPropertyCondition on amd64, also added Get_CurrentPropertyValue

### DIFF
--- a/iuiautomation_amd64.go
+++ b/iuiautomation_amd64.go
@@ -10,16 +10,13 @@ import (
 
 func createPropertyCondition(aut *IUIAutomation, propertyId PROPERTYID, value ole.VARIANT) (*IUIAutomationCondition, error) {
 	var newCondition *IUIAutomationCondition
-	v := VariantToUintptrArray(value)
 	hr, _, _ := syscall.Syscall6(
 		aut.VTable().CreatePropertyCondition,
-		6,
+		4,
 		uintptr(unsafe.Pointer(aut)),
 		uintptr(propertyId),
-		v[0],
-		v[1],
-		v[2],
-		uintptr(unsafe.Pointer(&newCondition)))
+		uintptr(unsafe.Pointer(&value)),
+		uintptr(unsafe.Pointer(&newCondition)), 0, 0)
 	if hr != 0 {
 		return nil, ole.NewError(hr)
 	}

--- a/iuiautomationelement.go
+++ b/iuiautomationelement.go
@@ -142,6 +142,10 @@ func (elem *IUIAutomationElement) Get_CurrentBoundingRectangle() (RECT, error) {
 	return get_CurrentBoundingRectangle(elem)
 }
 
+func (elem *IUIAutomationElement) Get_CurrentPropertyValue(propertyId PROPERTYID) (ole.VARIANT, error) {
+	return get_CurrentPropertyValue(elem, propertyId)
+}
+
 func setFocus(elem *IUIAutomationElement) (err error) {
 	hr, _, _ := syscall.Syscall(
 		elem.VTable().SetFocus,
@@ -260,4 +264,24 @@ func get_CurrentBoundingRectangle(elem *IUIAutomationElement) (rect RECT, err er
 		return
 	}
 	return
+}
+
+func get_CurrentPropertyValue(elem *IUIAutomationElement, propertyid PROPERTYID) (ole.VARIANT, error) {
+	var v ole.VARIANT
+
+	ole.VariantInit(&v)
+
+	hr, _, _ := syscall.Syscall(
+		elem.VTable().GetCurrentPropertyValue,
+		3,
+		uintptr(unsafe.Pointer(elem)),
+		uintptr(propertyid),
+		uintptr(unsafe.Pointer(&v)))
+
+	if hr != 0 {
+		err := ole.NewError(hr)
+		return v, err
+	}
+
+	return v, nil
 }


### PR DESCRIPTION
I compared the amd64 calls to CreatePropertyCondition from a working C++ and the existing Go version. The C++ appeared to be just passing a pointer to the Variant structure. I changed the Go version to do the same and it started working. I also verified that you do still have to unroll the struct for a 386.

I also implemented Get_CurrentPropertyValue